### PR TITLE
fixed #yh-issue-111, Show 'GO LABELLING'-btn & 'GO WRITE CRITERIA'-bt…

### DIFF
--- a/app/page/open_file.html
+++ b/app/page/open_file.html
@@ -11,9 +11,9 @@
     </div>
 
     <!-- open file -->
-    <button type="button" class="btn btn-link" name="go-labelling" id="open-file-next-page2" hidden>GO LABELLING</button>
+    <button type="button" class="btn btn-link" name="go-labelling" id="go-labbeling" hidden>GO LABELLING</button>
 
     <!-- create file -->
-    <button type="button" class="btn btn-link" name="go-criteria" id="open-file-next-page1" hidden>GO WRITE CRITERIA</button>
+    <button type="button" class="btn btn-link" name="go-criteria" id="go-write-criteria" hidden>GO WRITE CRITERIA</button>
   </div>
 </template>

--- a/src/page/file/createJSONFile.js
+++ b/src/page/file/createJSONFile.js
@@ -37,6 +37,7 @@ ipcRenderer.on("selected-json-directory", (event, pathArr) => {
   document.getElementById("json-file-path").innerText = creationPath;
 
   goCriteriaPageBtn.hidden = "";
+  document.getElementById("go-labbeling").hidden = true;
 });
 
 goCriteriaPageBtn.onclick = () => {
@@ -45,4 +46,5 @@ goCriteriaPageBtn.onclick = () => {
   document.querySelector("#open-file-path > p").innerHTML = `.&nbsp;.&nbsp.`;
 
   goCriteriaPageBtn.hidden = true;
+  document.getElementById("go-labbeling").hidden = true;
 }

--- a/src/page/file/importExistingFile.js
+++ b/src/page/file/importExistingFile.js
@@ -8,7 +8,7 @@ import jsonFileContainer from "../labelling/content/files/json/jsonFileContainer
 import jsonContentDTO from "../../model/dto/jsonFile";
 
 const openFileButton = document.getElementById("open-file-button");
-const goLabellingPageBtn = document.querySelector(`#open-file-page-container button[name="go-labelling"]`);
+const goLabellingPageBtn = document.getElementById("go-labbeling");
 
 let filePath;
 let jsonCriteria;
@@ -42,6 +42,7 @@ ipcRenderer.on("selected-file", (event, pathArr) => {
     document.querySelector("#open-file-path > p").innerText = filePath;
 
     goLabellingPageBtn.hidden = "";
+    document.getElementById("go-write-criteria").hidden = true;
 
     return;
   } else {

--- a/test/page/second/chooseJSONFileForm.js
+++ b/test/page/second/chooseJSONFileForm.js
@@ -1,0 +1,3 @@
+(() => {
+  document.getElementById("open-directory-page").style.display = "none";
+})();


### PR DESCRIPTION
…n swap

JSON 파일을 생성 할 때, '이 전 파일'을 가져오면 '기준 입력' 단계를 건너띄고, '작업 파일'을 생성 하면, '기준 입력' 단계를 밟는다.

다음 단계에 대한 지표를 버튼으로 보여주고 있는데, 동시에 두개의 버튼이 보이는 경우가 생겨 해결함.