### PR TITLE
#yh-issue-117, Main Frame view / Update labelling result

### DIFF
--- a/src/helpers/json/json_control.js
+++ b/src/helpers/json/json_control.js
@@ -104,7 +104,7 @@ const getLabellingDataInJSON = (jsonPath, fileName) => {
   let result = "";
 
   Array.prototype.some.call(labellingDataList, (labellingData) => {
-    if (labellingData.title = fileName) {
+    if (labellingData.title == fileName) {
       result = labellingData.frameList;
 
       return true;

--- a/src/page/labelling/content/control2/complete/updateBtnEvent.js
+++ b/src/page/labelling/content/control2/complete/updateBtnEvent.js
@@ -41,8 +41,6 @@ document.getElementById("update").addEventListener("click", (event) => {
 
   const labellingInfoList = labellingContainer.getLabellingData();
 
-  console.log("UPDATE, labellingInfoList: ", labellingInfoList);
-
   const VideoData = new videoDataDTO();
   VideoData.setTitle(VIDEO_TITLE)
     .convertLabellingDatasoFrameList(VIDEO_FRAME_LENGTH, labellingInfoList);

--- a/src/page/labelling/content/files/directory/videoFileEvent.js
+++ b/src/page/labelling/content/files/directory/videoFileEvent.js
@@ -20,7 +20,7 @@ videoFilesContainerTag.onclick = async (event) => {
     return false;
   }
 
-  if (!confirm(`${event.target.dataset.title} 에 대한 작업을 시작하시겠습니까? \n` +
+  if (!confirm(`'${event.target.dataset.title}' 에 대한 작업을 시작하시겠습니까? \n` +
     `(작업 시작 시, 비디오 제원에 대한 미리보기는 중단 됩니다.)`)) {
     return false;
   }
@@ -43,28 +43,28 @@ videoFilesContainerTag.onclick = async (event) => {
   mainViewContainer.initialize();
   frameListContainer.initialize();
   labellingContainer.initialize();
-
+  
   const path = event.target.dataset.path;
   
   const GlobalVideoData = new globalVideoData();
   GlobalVideoData.setPATH(path);
   GlobalVideoData.setTITLE(title);
-
+  
   const GlobalFrame = new globalFrame();
   GlobalFrame.setAT(0);
-
+  
   const video = mainViewContainer.getVideoTag(path);
-
+  
   mainViewContainer.setMainFrameRate(video);
-
+  
   const videoCaptureList = videoCapture.extractFrames(path, document.getElementById("hidden-video").clientWidth);
-
+  
   GlobalFrame.setLENGTH(videoCaptureList.length);
-
+  
   frameListContainer.showFrameList(videoCaptureList);
-
-  // 비디오 제원 : '파일명', '재생 시간', 'FPS', '프레임 수'
-  mainViewContainer.showVideoInfo(event);
+  
+  document.getElementById("main-view-image").hidden = false;
+  document.getElementById("hidden-video").hidden = true;
 
   remote.getGlobal("sharedObject").COMPLETE_FLAG = false;
 

--- a/src/page/labelling/content/files/json/jsonFileEvent.js
+++ b/src/page/labelling/content/files/json/jsonFileEvent.js
@@ -6,7 +6,6 @@ import globalFrame from "../../../../../model/global/globalFrame";
 import globalVideoData from "../../../../../model/global/globalVideoData";
 
 import videoCapture from "../../../../../helpers/video/videoCapture";
-import jsonControl from "../../../../../helpers/json/json_control";
 
 import mainViewContainer from "../../main/mainViewContainer";
 import frameListContainer from "../../control1/frame/frameListContainer";
@@ -15,6 +14,12 @@ import labellingContainer from "../../control2/complete/labellingContainer";
 const jsonFileContainer = document.getElementById("json-file-container");
 
 jsonFileContainer.onclick = async (event) => {
+
+  // 'COMPLETE' 시, 수정 기능 활성화.
+  if (!remote.getGlobal("sharedObject").COMPLETE_FLAG) {
+    alert("라벨링 작업 완료('COMPLETE') 후, 수정이 가능합니다.");
+    return false;
+  }
 
   if (event.target.className != "json-video-file") {
     return false;
@@ -55,6 +60,9 @@ jsonFileContainer.onclick = async (event) => {
 
   // show frame list
   frameListContainer.showFrameList(videoCaptureList);
+
+  document.getElementById("main-view-image").hidden = false;
+  document.getElementById("hidden-video").hidden = true;
 
   // show labelling data
   labellingContainer.showLabellingDataInJSON(


### PR DESCRIPTION
* 프레임 탐색 시, 메인 프레임에 표출 안되는 부분.
: 비디오 파일 클릭 시, 미리보기로 표현 되었던 부분에 대해서 초기화 작업이 이루어 진다.
: '미리보기' 에 대한 초기화 작업 시, 'video' 태그를 이용해 제원을 가져오기 때문에 'video' 태그가 활성화 됨.
: 'video' 태그가 활성화 됨에 따라, 프레임 리스트에서 선택한 프레임을 표현할 'img' 태그가 비활성화됨.
: 따라서, 비디오 파일 클릭 시, 'video' 태그가 활성화 된 채로 남아있게됨.
=> 비디오 파일 클릭 시, 비디오 제원에 대한 '미리보기' 초기화를 하지 않는 방법으로 문제를 해결함.

* 라벨링이 완료 된 파일에 대해서, 해당 비디오 파일에 대한 '라벨링 데이터 미리보기' 기능을 지원 중, 라벨링 데이터가 json 파일에 명시된 첫번째 리스트의 결과만 가져오는 것을 확인.
: '라벨링 데이터 미리보기' 의 경우, 라벨링 작업을 마친 후 json 파일에 쓰여진 데이터를 읽고, 파일명으로 라벨링 데이터를 찾아 표출해줌.
: 'mouseover' 시, 파일명이 제대로 전달 되지 않는 문제는 없었음.
: 따라서, json 파일에서 파일명을 가지고, 반복문을 수행하며 비디오 파일을 찾을 때의 문제라고 판단.
: 'some' 문으로 반복 할 때, 내부에 '=' 으로 비교하고 있는 것을 발견. 
==> '==' 으로 교체하여 해결. 

### '='
'=' 은 할당 연산자로, 조건문에서 실행시 항상 'true' 를 리턴함.
따라서, 위에 문제 시 항상 첫번째 반복문 에서 'true'를 반환하여, json에 존재하는 파일 리스트 중 항상 첫번째 원소만을 리턴함.